### PR TITLE
Make get certificates endpoint to return a page of certificates

### DIFF
--- a/backend/src/main/java/org/sefglobal/core/controller/CertificateController.java
+++ b/backend/src/main/java/org/sefglobal/core/controller/CertificateController.java
@@ -3,6 +3,7 @@ package org.sefglobal.core.controller;
 import org.sefglobal.core.exception.ResourceNotFoundException;
 import org.sefglobal.core.model.Certificate;
 import org.sefglobal.core.service.CertificateService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,8 +21,8 @@ public class CertificateController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public List<Certificate> getCertificates(){
-        return certificateService.getCertificates();
+    public Page<Certificate> getCertificates(@RequestParam int pageNumber, int pageSize){
+        return certificateService.getCertificates(pageNumber, pageSize);
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/org/sefglobal/core/service/CertificateService.java
+++ b/backend/src/main/java/org/sefglobal/core/service/CertificateService.java
@@ -3,6 +3,9 @@ package org.sefglobal.core.service;
 import org.sefglobal.core.exception.ResourceNotFoundException;
 import org.sefglobal.core.model.Certificate;
 import org.sefglobal.core.repository.CertificateRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -19,10 +22,13 @@ public class CertificateService {
     /**
      * Retrieves all the certificates in the repository
      *
-     * @return List of certificate objects
+     * @param pageNumber which is the starting index of the page
+     * @param pageSize   which is the size of the page
+     * @return {@link Page} of {@link Certificate}
      */
-    public List<Certificate> getCertificates(){
-        return certificateRepository.findAll();
+    public Page<Certificate> getCertificates(int pageNumber, int pageSize){
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        return certificateRepository.findAll(pageable);
     }
 
     /**


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #33 

## Goals
to make `GET fellowship/certificates` endpoint pageable

## Approach
Defined the request to ask for `pageNumber` and `pageSize` and made the `getCertificate` method to return a page using those variables.

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
N/A

## Test environment
- Java Version: OpenJDK 11.0.7
- Server: Tomcat 9
- Os: MacOs Catalina 10.15.3
- Test: Postman
