### PR TITLE
Add a breadcrumb for Items and Subcategories

### DIFF
--- a/frontend/app/src/scenes/Home/scenes/Category/index.tsx
+++ b/frontend/app/src/scenes/Home/scenes/Category/index.tsx
@@ -3,6 +3,7 @@ import axios, { AxiosResponse } from 'axios';
 import { CategoryStateProps } from './interfaces';
 import { Category } from '../../interfaces';
 import {
+  Breadcrumb,
   Button,
   Col,
   Divider,
@@ -16,6 +17,7 @@ import styles from './styles.css';
 import { handleApiError } from '../../../../services/util/errorHandler';
 import { Link } from 'react-router-dom';
 const { Title } = Typography;
+import { HomeOutlined } from '@ant-design/icons';
 
 class Categories extends React.Component<{}, CategoryStateProps> {
   constructor(props: {}) {
@@ -115,6 +117,14 @@ class Categories extends React.Component<{}, CategoryStateProps> {
     return (
       <Row className={styles.content}>
         <Col md={24} lg={{ span: 20, offset: 2 }}>
+          <Breadcrumb>
+            <Breadcrumb.Item>
+              <Link to={'/dashboard/home'}>
+                <HomeOutlined />
+              </Link>
+            </Breadcrumb.Item>
+            <Breadcrumb.Item>AcadeMix</Breadcrumb.Item>
+          </Breadcrumb>
           <Space className={styles.space}>
             <Title>Categories</Title>
             <Link

--- a/frontend/app/src/scenes/Home/scenes/Category/scenes/subcategories/index.tsx
+++ b/frontend/app/src/scenes/Home/scenes/Category/scenes/subcategories/index.tsx
@@ -1,13 +1,24 @@
 import React from 'react';
 import axios, { AxiosResponse } from 'axios';
 import { CategoryStateProps, CategoryUrlParams } from './interfaces';
-import { SubCategory } from '../../../../interfaces';
-import { Button, Col, Divider, Popconfirm, Row, Table, Typography } from 'antd';
+import { Category, SubCategory } from '../../../../interfaces';
+import {
+  Breadcrumb,
+  Button,
+  Col,
+  Divider,
+  Popconfirm,
+  Row,
+  Table,
+  Typography,
+} from 'antd';
 import styles from './styles.css';
+import mainStyles from '../../../../styles.css';
 import { handleApiError } from '../../../../../../services/util/errorHandler';
 import { Link } from 'react-router-dom';
 const { Title } = Typography;
 import { RouteComponentProps } from 'react-router';
+import { HomeOutlined } from '@ant-design/icons';
 
 class SubCategories extends React.Component<
   RouteComponentProps<CategoryUrlParams>,
@@ -20,10 +31,12 @@ class SubCategories extends React.Component<
     this.state = {
       isLoading: false,
       subCategories: [],
+      category: null,
     };
   }
   componentDidMount() {
     this.fetchSubCategories();
+    this.fetchCategory();
   }
 
   fetchSubCategories() {
@@ -47,6 +60,27 @@ class SubCategories extends React.Component<
           'Something went wrong when trying to load sub-categories'
         );
         this.setState({ isLoading: false });
+      });
+  }
+
+  // Fetch category details to show the category name in the breadcrumb
+  fetchCategory() {
+    axios
+      .get(
+        window.location.origin + `/core/academix/categories/${this.categoryId}`
+      )
+      .then((result: AxiosResponse<Category>) => {
+        if (result.status == 200) {
+          this.setState({
+            category: result.data,
+          });
+        }
+      })
+      .catch((error) => {
+        handleApiError(
+          error,
+          'Something went wrong when trying to load the category details'
+        );
       });
   }
 
@@ -122,10 +156,25 @@ class SubCategories extends React.Component<
   ];
 
   render() {
+    const { category } = this.state;
     return (
       <Row className={styles.content}>
         <Col md={24} lg={{ span: 20, offset: 2 }}>
-          <Title>Subcategories</Title>
+          <Breadcrumb>
+            <Breadcrumb.Item>
+              <Link to={'/dashboard/home'}>
+                <HomeOutlined />
+              </Link>
+            </Breadcrumb.Item>
+            <Breadcrumb.Item>
+              <Link to={'/dashboard/academix/categories'}>AcadeMix</Link>
+            </Breadcrumb.Item>
+            <Breadcrumb.Item>
+              {/* Checks if the category details are available to render the category name */}
+              <span>{category != null && category.name}</span>
+            </Breadcrumb.Item>
+          </Breadcrumb>
+          <Title className={mainStyles.mainTitle}>Subcategories</Title>
           <Table
             rowKey="id"
             columns={this.columns}

--- a/frontend/app/src/scenes/Home/scenes/Category/scenes/subcategories/interfaces.ts
+++ b/frontend/app/src/scenes/Home/scenes/Category/scenes/subcategories/interfaces.ts
@@ -1,8 +1,9 @@
-import { SubCategory } from '../../../../interfaces';
+import { Category, SubCategory } from '../../../../interfaces';
 
 export interface CategoryStateProps {
   isLoading: boolean;
   subCategories: SubCategory[];
+  category: Category | null;
 }
 
 export interface CategoryUrlParams {

--- a/frontend/app/src/scenes/Home/scenes/Category/scenes/subcategories/scenes/interfaces.ts
+++ b/frontend/app/src/scenes/Home/scenes/Category/scenes/subcategories/scenes/interfaces.ts
@@ -1,4 +1,4 @@
-import { Item } from '../../../../../interfaces';
+import { Item, SubCategory } from '../../../../../interfaces';
 
 export interface ItemStateProps {
   items: Item[];
@@ -8,6 +8,7 @@ export interface ItemStateProps {
     pageSize: number,
     total: number,
   };
+  subCategory: SubCategory | null;
 }
 
 export interface ItemPayload {

--- a/frontend/app/src/scenes/Home/styles.css
+++ b/frontend/app/src/scenes/Home/styles.css
@@ -48,3 +48,11 @@
         margin-left: 200px;
     }
 }
+
+:global h1.ant-typography, :global h2.ant-typography, :global h3.ant-typography, :global h4.ant-typography {
+    font-weight: 300;
+}
+
+.mainTitle {
+    margin-top: 5px;
+}


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
- The purpose of this PR is to fix #76 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
- Showing page titles
## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
- Create a function to fetch selected category details.
- Create a function to fetch selected Subcategory details.
- Add breadcrumb and link them to relevant places.
![Kapture 2020-07-20 at 17 53 47](https://user-images.githubusercontent.com/43912578/87937318-214e7200-cab2-11ea-85e9-81c650477c11.gif)

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

