### PR TITLE
Prevent deleting subcategories when updating a category

### DIFF
--- a/backend/src/main/java/org/sefglobal/core/academix/model/Category.java
+++ b/backend/src/main/java/org/sefglobal/core/academix/model/Category.java
@@ -33,7 +33,6 @@ public class Category extends AuditModel {
     private List<CategoryTranslation> translations = new ArrayList<>();
 
     @OneToMany(mappedBy = "category",
-               cascade = CascadeType.ALL,
                orphanRemoval = true)
     private List<SubCategory> subCategories = new ArrayList<>();
 


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #90 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Prevent deleting subcategories when updating a category

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
In the current version, when updating a category it deletes the entites because the cascadeType is cascadeType.ALL
So the SubCategories get removed if only the name is sent with the PUT request body
In this PR, the cascade type is removed

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 
N/A

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
Ubuntu 19.04
Postman
OpenJDK 1.8

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
N/A