### PR TITLE
Whitelist fellowship APIs

### DIFF
--- a/backend/src/main/java/org/sefglobal/core/config/SecurityConfig.java
+++ b/backend/src/main/java/org/sefglobal/core/config/SecurityConfig.java
@@ -45,6 +45,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .antMatchers("/link/*").permitAll()
                     .antMatchers("/academix/admin/**").authenticated()
                     .antMatchers("/academix/**").permitAll()
+                    .antMatchers("/fellowship/admin/**").authenticated()
+                    .antMatchers("/fellowship/**").permitAll()
                     .anyRequest().authenticated()
                 .and()
                     .formLogin()

--- a/backend/src/main/java/org/sefglobal/core/fellowship/controller/CertificateController.java
+++ b/backend/src/main/java/org/sefglobal/core/fellowship/controller/CertificateController.java
@@ -1,0 +1,24 @@
+package org.sefglobal.core.fellowship.controller;
+
+import org.sefglobal.core.exception.ResourceNotFoundException;
+import org.sefglobal.core.fellowship.model.Certificate;
+import org.sefglobal.core.fellowship.service.CertificateService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/fellowship/certificates")
+public class CertificateController {
+
+    private final CertificateService certificateService;
+
+    public CertificateController(CertificateService certificateService) {
+        this.certificateService = certificateService;
+    }
+
+    @GetMapping("/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    public Certificate getCertificateById(@PathVariable Integer id) throws ResourceNotFoundException{
+        return certificateService.getCertificateById(id);
+    }
+}

--- a/backend/src/main/java/org/sefglobal/core/fellowship/controller/admin/CertificateAdminController.java
+++ b/backend/src/main/java/org/sefglobal/core/fellowship/controller/admin/CertificateAdminController.java
@@ -1,21 +1,19 @@
-package org.sefglobal.core.controller;
+package org.sefglobal.core.fellowship.controller.admin;
 
 import org.sefglobal.core.exception.ResourceNotFoundException;
-import org.sefglobal.core.model.Certificate;
-import org.sefglobal.core.service.CertificateService;
+import org.sefglobal.core.fellowship.model.Certificate;
+import org.sefglobal.core.fellowship.service.CertificateService;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
-@RequestMapping("/fellowship/certificates")
-public class CertificateController {
+@RequestMapping("/fellowship/admin/certificates")
+public class CertificateAdminController {
 
     private final CertificateService certificateService;
 
-    public CertificateController(CertificateService certificateService) {
+    public CertificateAdminController(CertificateService certificateService) {
         this.certificateService = certificateService;
     }
 
@@ -23,12 +21,6 @@ public class CertificateController {
     @ResponseStatus(HttpStatus.OK)
     public Page<Certificate> getCertificates(@RequestParam int pageNumber, int pageSize){
         return certificateService.getCertificates(pageNumber, pageSize);
-    }
-
-    @GetMapping("/{id}")
-    @ResponseStatus(HttpStatus.OK)
-    public Certificate getCertificateById(@PathVariable(value = "id") Integer id) throws ResourceNotFoundException{
-        return certificateService.getCertificateById(id);
     }
 
     @PostMapping
@@ -39,7 +31,7 @@ public class CertificateController {
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public String deleteCertificateById(@PathVariable(value = "id") Integer id) throws ResourceNotFoundException {
+    public String deleteCertificateById(@PathVariable Integer id) throws ResourceNotFoundException {
         return certificateService.deleteCertificate(id);
     }
 }

--- a/backend/src/main/java/org/sefglobal/core/fellowship/model/Certificate.java
+++ b/backend/src/main/java/org/sefglobal/core/fellowship/model/Certificate.java
@@ -1,8 +1,9 @@
-package org.sefglobal.core.model;
+package org.sefglobal.core.fellowship.model;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import org.sefglobal.core.model.AuditModel;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -12,7 +13,7 @@ import java.util.Date;
 @Table(name = "certificate")
 @Getter
 @Setter
-public class Certificate extends AuditModel{
+public class Certificate extends AuditModel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/backend/src/main/java/org/sefglobal/core/fellowship/repository/CertificateRepository.java
+++ b/backend/src/main/java/org/sefglobal/core/fellowship/repository/CertificateRepository.java
@@ -1,6 +1,6 @@
-package org.sefglobal.core.repository;
+package org.sefglobal.core.fellowship.repository;
 
-import org.sefglobal.core.model.Certificate;
+import org.sefglobal.core.fellowship.model.Certificate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CertificateRepository extends JpaRepository<Certificate, Integer> {

--- a/backend/src/main/java/org/sefglobal/core/fellowship/service/CertificateService.java
+++ b/backend/src/main/java/org/sefglobal/core/fellowship/service/CertificateService.java
@@ -1,14 +1,12 @@
-package org.sefglobal.core.service;
+package org.sefglobal.core.fellowship.service;
 
 import org.sefglobal.core.exception.ResourceNotFoundException;
-import org.sefglobal.core.model.Certificate;
-import org.sefglobal.core.repository.CertificateRepository;
+import org.sefglobal.core.fellowship.model.Certificate;
+import org.sefglobal.core.fellowship.repository.CertificateRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 public class CertificateService {


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #51 

## Goals
To divide the controller into `admin` and `public` 
To whitelist the APIs

## Approach
- Changed the folder structure
  - Created a new package `fellowship`
  - Created `model`, `controller`, `service` and `repository` packages under `fellowship`
  - Created `admin` package under `controller`
- Divided the current controller into two as `/fellowship/admin` and `fellowship` so that one with the `admin` postfix has the endpoints to delete, create and list all the certificates while the other can only get one certificate by a requested id.
- Configured `SecurityConfig` file to authorize `/fellowship/admin` endpoints and to give permission for all to access `/fellowship` endpoints

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related PRs
N/A 

## Test environment
Java Version: OpenJDK 11.0.7
TestServer: Tomcat 9
Os: MacOs Catalina 10.15.3
Test: Postman, Google Chrome


## Learning
N/A
